### PR TITLE
Removed mandatory fields to aligned with Arbor

### DIFF
--- a/src/orgid-json-schema.yaml
+++ b/src/orgid-json-schema.yaml
@@ -282,11 +282,9 @@ definitions:
     type: object
     required:
       - country
-      - subdivision
       - locality
       - postalCode
       - streetAddress
-      - premise
     properties:
       country:
         description: ISO 3166-1 alpha-2 country code


### PR DESCRIPTION
Removed two mandatory fields which are making the JSON Schema validation fail for organizations created from Arbor